### PR TITLE
Adding support for Travis CI and continuous integration

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@
 ^\.Rproj\.user$
 out
 R/deprecated.R$
+.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,9 @@ language: c
 
 env:
   global:
-    # uncommented '--no-build-vignettes' here as we can;
-    # still '--no-manual' to avoid a full latex install
     # uncommented '--as-cran' as we don't need it here 
-    - R_BUILD_ARGS="--no-manual"
-    - R_CHECK_ARGS="--no-manual"
+    - R_BUILD_ARGS="--no-build-vignettes --no-manual"
+    - R_CHECK_ARGS="--no-build-vignettes --no-manual"
     - _R_CHECK_FORCE_SUGGESTS_=FALSE
     # we cannot 'really' fix the x13ashtml file as we cannot write on /usr
     - X13_PATH="/tmp"
@@ -35,13 +33,13 @@ before_install:
   - ./travis-tool.sh bootstrap
 
 install:
-  - ./travis-tool.sh install_aptget r-cran-readr r-cran-dplyr r-cran-stringr r-cran-seasonal r-cran-ggplot2 r-cran-data.table r-cran-zoo r-cran-git2r r-cran-knitr r-cran-rmarkdown
+  - ./travis-tool.sh install_aptget r-cran-readr r-cran-dplyr r-cran-stringr r-cran-seasonal r-cran-ggplot2 r-cran-data.table r-cran-zoo
   ## repair x13binary re-install the binary which launchpad somewhat does NOT
   ## (which is probably fine on security/license grounds -- they cannot know)
   ## (and just to reiterate: this is code by the US Census Bureau which
   ##  cannot be copyrighted in the US; see the GitHub repo for more)
   ## (removed curl's '-s' for now to make download explicit)
-  - cd /tmp && curl -k -L -O https://github.com/x13org/x13prebuilt/raw/master/linux/64/x13ashtml && cd -
+  - cd /tmp && curl -k -L -O https://github.com/x13org/x13prebuilt/raw/master/linux/64/x13ashtml && chmod 0755 x13ashtml && cd -
 
 script:
   - ./travis-tool.sh run_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+# Hey Emacs make this  -*- mode: makefile; -*-
+#
+# Sample .travis.yml for R projects.
+#
+# See https://github.com/craigcitro/r-travis
+#     https://github.com/eddelbuettel/r-travis/
+
+# new-ish requirement
+sudo: required
+
+# may as well switch to trusty aka 14.04
+dist: trusty
+
+language: c
+
+env:
+  global:
+    # uncommented '--no-build-vignettes' here as we can;
+    # still '--no-manual' to avoid a full latex install
+    # uncommented '--as-cran' as we don't need it here 
+    - R_BUILD_ARGS="--no-manual"
+    - R_CHECK_ARGS="--no-manual"
+    - _R_CHECK_FORCE_SUGGESTS_=FALSE
+
+before_install:
+  ## PPA for seasonal and x13binary which are not (yet?) packaged by Michael
+  ## Note, however, that the launchpad build of x13binary is BORKED:
+  ## no actual binary
+  - sudo add-apt-repository -y ppa:edd/misc
+  ## r-travis by Craig Citro et al, this covers the two PPAs by Michael
+  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
+  - chmod 755 ./travis-tool.sh
+  - ./travis-tool.sh bootstrap
+
+install:
+  - ./travis-tool.sh install_aptget r-cran-readr r-cran-dplyr r-cran-stringr r-cran-seasonal r-cran-ggplot2 r-cran-data.table r-cran-zoo r-cran-git2r r-cran-knitr 
+  ## repair x13binary re-install the binary which launchpad somewhat does NOT
+  ## (which is probably fine on security/license grounds -- they cannot know)
+  ## (and just to reiterate: this is code by the US Census Bureau which
+  ##  cannot be copyrighted in the US; see the GitHub repo for more)
+  ## (removed curl's '-s' for now to make download explicit)
+  - cd /usr/lib/R/site-library/x13binary/bin && curl -k -L -O https://github.com/x13org/x13prebuilt/raw/master/linux/64/x13ashtml
+
+script:
+  - ./travis-tool.sh run_tests
+
+after_failure:
+  - ./travis-tool.sh dump_logs
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - ./travis-tool.sh bootstrap
 
 install:
-  - ./travis-tool.sh install_aptget r-cran-readr r-cran-dplyr r-cran-stringr r-cran-seasonal r-cran-ggplot2 r-cran-data.table r-cran-zoo
+  - ./travis-tool.sh install_aptget r-cran-readr r-cran-dplyr r-cran-stringr r-cran-seasonal r-cran-ggplot2 r-cran-data.table r-cran-zoo r-cran-knitr
   ## repair x13binary re-install the binary which launchpad somewhat does NOT
   ## (which is probably fine on security/license grounds -- they cannot know)
   ## (and just to reiterate: this is code by the US Census Bureau which

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   ## (and just to reiterate: this is code by the US Census Bureau which
   ##  cannot be copyrighted in the US; see the GitHub repo for more)
   ## (removed curl's '-s' for now to make download explicit)
-  - cd /usr/lib/R/site-library/x13binary/bin && curl -k -L -O https://github.com/x13org/x13prebuilt/raw/master/linux/64/x13ashtml
+  - cd /usr/lib/R/site-library/x13binary/bin && rm -vf x13ashtml && touch RootCanWriteHere && curl -k -L -O https://github.com/x13org/x13prebuilt/raw/master/linux/64/x13ashtml
 
 script:
   - ./travis-tool.sh run_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
   ## (and just to reiterate: this is code by the US Census Bureau which
   ##  cannot be copyrighted in the US; see the GitHub repo for more)
   ## (removed curl's '-s' for now to make download explicit)
-  - cd /tmp && curl -k -L -O https://github.com/x13org/x13prebuilt/raw/master/linux/64/x13ashtml
+  - cd /tmp && curl -k -L -O https://github.com/x13org/x13prebuilt/raw/master/linux/64/x13ashtml && cd -
 
 script:
   - ./travis-tool.sh run_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   - ./travis-tool.sh bootstrap
 
 install:
-  - ./travis-tool.sh install_aptget r-cran-readr r-cran-dplyr r-cran-stringr r-cran-seasonal r-cran-ggplot2 r-cran-data.table r-cran-zoo r-cran-git2r r-cran-knitr 
+  - ./travis-tool.sh install_aptget r-cran-readr r-cran-dplyr r-cran-stringr r-cran-seasonal r-cran-ggplot2 r-cran-data.table r-cran-zoo r-cran-git2r r-cran-knitr r-cran-rmarkdown
   ## repair x13binary re-install the binary which launchpad somewhat does NOT
   ## (which is probably fine on security/license grounds -- they cannot know)
   ## (and just to reiterate: this is code by the US Census Bureau which

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ env:
     - R_BUILD_ARGS="--no-manual"
     - R_CHECK_ARGS="--no-manual"
     - _R_CHECK_FORCE_SUGGESTS_=FALSE
+    # we cannot 'really' fix the x13ashtml file as we cannot write on /usr
+    - X13_PATH="/tmp"
 
 before_install:
   ## PPA for seasonal and x13binary which are not (yet?) packaged by Michael
@@ -39,7 +41,7 @@ install:
   ## (and just to reiterate: this is code by the US Census Bureau which
   ##  cannot be copyrighted in the US; see the GitHub repo for more)
   ## (removed curl's '-s' for now to make download explicit)
-  - cd /usr/lib/R/site-library/x13binary/bin && rm -vf x13ashtml && touch RootCanWriteHere && curl -k -L -O https://github.com/x13org/x13prebuilt/raw/master/linux/64/x13ashtml
+  - cd /tmp && curl -k -L -O https://github.com/x13org/x13prebuilt/raw/master/linux/64/x13ashtml
 
 script:
   - ./travis-tool.sh run_tests

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gunsales
 Type: Package
 Title: Statistical Analysis of Monthly Background Checks of Gun Purchases
-Version: 0.1.0.1
-Date: 2016-02-14
+Version: 0.1.0
+Date: 2016-02-27
 Author: Gregor Aisch, Josh Keller and Dirk Eddelbuettel
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: Statistical analysis of monthly background checks of gun purchases for the New York Times 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gunsales
 Type: Package
 Title: Statistical Analysis of Monthly Background Checks of Gun Purchases
-Version: 0.1.0
+Version: 0.1.0.1
 Date: 2016-02-14
 Author: Gregor Aisch, Josh Keller and Dirk Eddelbuettel
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
@@ -10,7 +10,7 @@ Description: Statistical analysis of monthly background checks of gun purchases 
  <http://www.nytimes.com/interactive/2015/12/10/us/gun-sales-terrorism-obama-restrictions.html?> is provided.
 License: Apache License (== 2)
 Depends: R (>= 2.10)
-LazyData: yes
+LazyData: true
 Imports: readr, dplyr, stringr, seasonal, ggplot2, data.table, zoo
 Suggests: knitr
 VignetteBuilder: knitr

--- a/R/analysis.R
+++ b/R/analysis.R
@@ -14,10 +14,6 @@
 #' gs <- analysis()
 analysis <- function(debug=FALSE) {
     
-    ## load data sets included in package
-    data("alldata", envir=environment())              
-    data("poptotal", envir=environment())
-
     ## estimate gun sales using formula by Jurgen Brauer, published here
     ## http://www.smallarmssurvey.org/fileadmin/docs/F-Working-papers/SAS-WP14-US-Firearms-Industry.pdf
     ##

--- a/vignettes/gunsales.Rmd
+++ b/vignettes/gunsales.Rmd
@@ -39,7 +39,7 @@ publication).
 plot_gunsales(gunsales)
 ```
 
-## Part III: Base Plots
+## Part III: Using ggplot
 
 The second set of charts redisplays the same charts as before, but using the
 [ggplot2](http://cloud.r-project.org/package=ggplot2) package.


### PR DESCRIPTION
Note that this will **not work** in your main repo as you still have not enabled Travis CI support -- see [Issue #10](https://github.com/NYTimes/gunsales/issues/10) which I used twelve days ago and which has so far been ignored completely -- I understand you keep busy with election work.

Stale code sucks, though, so I intend to merge this PR anyway in about a day.

My offer to walk you through enabling Travis CI stands; I left several emails.  See [here](https://travis-ci.org/eddelbuettel/gunsales) for Travis CI builds of the local fork I keep -- as it is the only way to have Travis CI on via a repo where I can enable this (which I can't for your repo).

/cc @gka @joshkeller 
