### PR TITLE
Enable Continuous Integration via GitHub Actions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,4 +2,5 @@
 ^\.Rproj\.user$
 out
 R/deprecated.R$
-.travis.yml
+^\.travis.yml$
+^\.github

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,40 @@
+# Run CI for R using https://eddelbuettel.github.io/r-ci/
+
+name: ci
+
+on:
+  push:
+  pull_request:
+
+env:
+  USE_BSPM: "true"
+  _R_CHECK_FORCE_SUGGESTS_: "false"
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+        include:
+          - {os: macOS-latest}
+          - {os: ubuntu-latest}
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Bootstrap
+        run: |
+          curl -OLs https://eddelbuettel.github.io/r-ci/run.sh
+          chmod 0755 run.sh
+          ./run.sh bootstrap
+
+      - name: Dependencies
+        run: ./run.sh install_all
+
+      - name: Test
+        run: ./run.sh run_tests
+
+      #- name: Coverage
+      #  if: ${{ matrix.os == 'ubuntu-latest' }}
+      #  run: ./run.sh coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,6 @@ on:
   pull_request:
 
 env:
-  USE_BSPM: "true"
   _R_CHECK_FORCE_SUGGESTS_: "false"
 
 jobs:
@@ -15,26 +14,29 @@ jobs:
     strategy:
       matrix:
         include:
-          - {os: macOS-latest}
-          - {os: ubuntu-latest}
+          #- {os: macOS-latest}
+          - {os: ubuntu-slim}
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
-      - name: Bootstrap
-        run: |
-          curl -OLs https://eddelbuettel.github.io/r-ci/run.sh
-          chmod 0755 run.sh
-          ./run.sh bootstrap
-
+      - name: Setup
+        uses: eddelbuettel/github-actions/r-ci@master
+        
       - name: Dependencies
         run: ./run.sh install_all
 
       - name: Test
         run: ./run.sh run_tests
 
+      #- name: Logs
+      #  run: ./run.sh dump_logs
+      #  if: failure()
+        
       #- name: Coverage
       #  if: ${{ matrix.os == 'ubuntu-latest' }}
       #  run: ./run.sh coverage
+      #  env:
+      #    CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}  

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,5 +13,7 @@ Depends: R (>= 2.10)
 LazyData: true
 Imports: utils, dplyr, seasonal, ggplot2, data.table, zoo, x13binary
 Suggests: knitr, rmarkdown
+URL: https://github.com/eddelbuettel/gunsales
+BugReports: https://github.com/eddelbuettel/gunsales/issues
 VignetteBuilder: knitr
 RoxygenNote: 5.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: Statistical analysis of monthly background checks of gun purchases 
 License: Apache License (== 2)
 Depends: R (>= 2.10)
 LazyData: true
-Imports: utils, dplyr, seasonal, ggplot2, data.table, zoo, x13binary
+Imports: utils, dplyr, rlang, seasonal, ggplot2, data.table, zoo, x13binary
 Suggests: knitr, rmarkdown
 URL: https://github.com/eddelbuettel/gunsales
 BugReports: https://github.com/eddelbuettel/gunsales/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,13 +3,14 @@ Type: Package
 Title: Statistical Analysis of Monthly Background Checks of Gun Purchases
 Version: 0.1.2
 Date: 2017-01-30
-Author: Gregor Aisch, Josh Keller and Dirk Eddelbuettel
-Maintainer: Dirk Eddelbuettel <edd@debian.org>
+Authors@R: c(person(given = "Gregor", family = "Aisch", role = "aut"),
+             person(given = "Josh", family = "Keller", role = "aut"),
+             person(given = "Dirk", family = "Eddelbuettel", role = c("aut", "cre"),
+                    email = "edd@debian.org", comment = c(ORCID = "0000-0001-6419-907X")))
 Description: Statistical analysis of monthly background checks of gun purchases for the New York Times 
  story "What Drives Gun Sales: Terrorism, Obama and Calls for Restrictions" at 
  <http://www.nytimes.com/interactive/2015/12/10/us/gun-sales-terrorism-obama-restrictions.html?> is provided.
 License: Apache License (== 2)
-Depends: R (>= 2.10)
 LazyData: true
 Imports: utils, dplyr, rlang, seasonal, ggplot2, data.table, zoo, x13binary
 Suggests: knitr, rmarkdown

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,7 +2,8 @@
 export("analysis", "plot_gunsales", "ggplot_gunsales")
 
 importFrom("dplyr", "mutate", "%>%", "filter", "left_join", "select", "group_by",
-           "summarize", "arrange", "select_", "last")
+           "summarize", "arrange", "last")
+importFrom("rlang", ".data")
 importFrom("seasonal", "seas", "final")
 importFrom("x13binary", "supportedPlatform")
 importFrom("grDevices", "dev.off", "pdf", "png")

--- a/R/functions.R
+++ b/R/functions.R
@@ -2,7 +2,7 @@ state_ts <- function(data, state_ts, column='guns_sold', outer_zeros_to_na=TRUE)
    d <- data %>%
         filter(state == state_ts & (year >= 2000)) %>%
         arrange(year, month.num) %>%
-        select_('year', month='month.num', value=column)
+        select(year, month = month.num, value = .data[[column]])
    # d$value[d$value == 0] <- NA
    series <- ts(d$value, start=c(d$year[1],d$month[1]), end=c(last(d$year), last(d$month)), frequency = 12)
    if (outer_zeros_to_na) series <- replace_outer_zeros(series)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Analysis of NICS gun purchase background checks
 
-[![Build Status](https://travis-ci.org/NYTimes/gunsales.svg)](https://travis-ci.org/NYTimes/gunsales) [![License](http://img.shields.io/badge/license-Apache%20%28=%202%29-brightgreen.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0) [![CRAN](http://www.r-pkg.org/badges/version/gunsales)](https://cran.r-project.org/package=gunsales) [![Downloads](http://cranlogs.r-pkg.org/badges/gunsales?color=brightgreen)](http://www.r-pkg.org/pkg/gunsales)
+[![Build Status](https://travis-ci.org/NYTimes/gunsales.svg)](https://travis-ci.org/NYTimes/gunsales) 
+[![License](http://img.shields.io/badge/license-Apache%20%28=%202%29-brightgreen.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0) 
+[![CRAN](http://www.r-pkg.org/badges/version/gunsales)](https://cran.r-project.org/package=gunsales) 
+[![Downloads](http://cranlogs.r-pkg.org/badges/gunsales?color=brightgreen)](http://www.r-pkg.org/pkg/gunsales)
 
 Statistical analysis of monthly background checks of gun purchases for the New York Times story [What Drives Gun Sales: Terrorism,
 Obama and Calls for Restrictions](http://www.nytimes.com/interactive/2015/12/10/us/gun-sales-terrorism-obama-restrictions.html?).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Analysis of NICS gun purchase background checks
 
-[![Build Status](https://travis-ci.org/NYTimes/gunsales.svg)](https://travis-ci.org/NYTimes/gunsales) 
+[![Build Status](https://github.com/eddelbuettel/gunsales/actions/workflows/ci.yaml/badge.svg)](https://github.com/eddelbuettel/gunsales/actions/workflows/ci.yaml)
 [![License](https://img.shields.io/badge/license-Apache%20%28=%202%29-brightgreen.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0) 
 [![CRAN](https://www.r-pkg.org/badges/version/gunsales)](https://cran.r-project.org/package=gunsales) 
 [![Downloads](https://cranlogs.r-pkg.org/badges/gunsales?color=brightgreen)](https://www.r-pkg.org/pkg/gunsales)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Analysis of NICS gun purchase background checks
 
 [![Build Status](https://travis-ci.org/NYTimes/gunsales.svg)](https://travis-ci.org/NYTimes/gunsales) 
-[![License](http://img.shields.io/badge/license-Apache%20%28=%202%29-brightgreen.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0) 
-[![CRAN](http://www.r-pkg.org/badges/version/gunsales)](https://cran.r-project.org/package=gunsales) 
-[![Downloads](http://cranlogs.r-pkg.org/badges/gunsales?color=brightgreen)](http://www.r-pkg.org/pkg/gunsales)
+[![License](https://img.shields.io/badge/license-Apache%20%28=%202%29-brightgreen.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0) 
+[![CRAN](https://www.r-pkg.org/badges/version/gunsales)](https://cran.r-project.org/package=gunsales) 
+[![Downloads](https://cranlogs.r-pkg.org/badges/gunsales?color=brightgreen)](https://www.r-pkg.org/pkg/gunsales)
 
 Statistical analysis of monthly background checks of gun purchases for the New York Times story [What Drives Gun Sales: Terrorism,
-Obama and Calls for Restrictions](http://www.nytimes.com/interactive/2015/12/10/us/gun-sales-terrorism-obama-restrictions.html?).
+Obama and Calls for Restrictions](https://www.nytimes.com/interactive/2015/12/10/us/gun-sales-terrorism-obama-restrictions.html?).
 
 ### Pre-requisites
 
@@ -55,12 +55,12 @@ to create, respectively, plots via R base or
 
 ### Data issues
 
-The source data comes from the [FBI's National Instant Criminal Background Check System](https://www.fbi.gov/about-us/cjis/nics), and was converted from the original [PDF format](https://www.fbi.gov/file-repository/nics_firearm_checks_-_month_year_by_state_type.pdf) to CSV using [Tabula](http://tabula.technology/).
+The source data comes from the [FBI's National Instant Criminal Background Check System](https://www.fbi.gov/about-us/cjis/nics), and was converted from the original [PDF format](https://www.fbi.gov/file-repository/nics_firearm_checks_-_month_year_by_state_type.pdf) to CSV using [Tabula](https://tabula.technology/).
 
 BuzzFeed also released the same dataset on [Github](https://github.com/BuzzFeedNews/nics-firearm-background-checks/) last week.
 
 #### Getting gun sales estimates from background checks
 
-To convert background checks into estimated sales, we relied on a method suggested in the [Small Arms Survey](http://www.smallarmssurvey.org/fileadmin/docs/F-Working-papers/SAS-WP14-US-Firearms-Industry.pdf) by Jurgen Brauer, a professor at Georgia Regents University. Each long gun and handgun check was counted as 1.1 sales. Each multiple-gun check was counted as two sales. Permit checks and other types of checks were omitted. The multiplier is an estimate based on Mr. Brauer's interviews with gun shop owners.
+To convert background checks into estimated sales, we relied on a method suggested in the [Small Arms Survey](https://www.smallarmssurvey.org/fileadmin/docs/F-Working-papers/SAS-WP14-US-Firearms-Industry.pdf) by Jurgen Brauer, a professor at Georgia Regents University. Each long gun and handgun check was counted as 1.1 sales. Each multiple-gun check was counted as two sales. Permit checks and other types of checks were omitted. The multiplier is an estimate based on Mr. Brauer's interviews with gun shop owners.
 
 Note: In our computation, we excluded background checks for the "multiple" category in California because they followed an unusual pattern that did not match California gun sales data.


### PR DESCRIPTION
The once-dominant Travis service switched to a subscription-only/mostly model.  

Many open source project have switched to alternatives, notable GitHub Actions.  While updating my repositories I noticed that this one (which I contributed to years ago) still has only the old `.travis.yml`.  

This pull request offers a newer alternative you want it, see the first two run results [here](https://github.com/eddelbuettel/gunsales/actions).